### PR TITLE
Combine identical metrics into single data frame

### DIFF
--- a/telemetry/telegraf/convert_test.go
+++ b/telemetry/telegraf/convert_test.go
@@ -31,8 +31,8 @@ func TestConverter_Convert(t *testing.T) {
 		NumFrames   int
 	}{
 		{Name: "single_metric", NumFields: 6, FieldLength: 1, NumFrames: 1},
-		{Name: "same_metrics_same_labels_different_time", NumFields: 6, FieldLength: 1, NumFrames: 2},
-		{Name: "same_metrics_different_labels_different_time", NumFields: 6, FieldLength: 1, NumFrames: 2},
+		{Name: "same_metrics_same_labels_different_time", NumFields: 6, FieldLength: 3, NumFrames: 1},
+		{Name: "same_metrics_different_labels_different_time", NumFields: 11, FieldLength: 1, NumFrames: 1},
 		{Name: "same_metrics_different_labels_same_time", NumFields: 131, FieldLength: 1, NumFrames: 1},
 	}
 
@@ -62,7 +62,7 @@ func TestConverter_Convert_LabelsColumn(t *testing.T) {
 		NumFrames   int
 	}{
 		{Name: "single_metric", NumFields: 7, FieldLength: 1, NumFrames: 1},
-		{Name: "same_metrics_same_labels_different_time", NumFields: 7, FieldLength: 2, NumFrames: 1},
+		{Name: "same_metrics_same_labels_different_time", NumFields: 7, FieldLength: 3, NumFrames: 1},
 		{Name: "same_metrics_different_labels_different_time", NumFields: 7, FieldLength: 2, NumFrames: 1},
 		{Name: "same_metrics_different_labels_same_time", NumFields: 12, FieldLength: 13, NumFrames: 1},
 	}

--- a/telemetry/telegraf/testdata/same_metrics_same_labels_different_time.txt
+++ b/telemetry/telegraf/testdata/same_metrics_same_labels_different_time.txt
@@ -1,2 +1,3 @@
 system,host=MacBook-Pro-Alexander.local,mylabel=boom load15=2.00341796875,n_cpus=12i,n_users=6i,load1=3.15966796875,load5=2.3837890625 1616403089000000000
-system,host=MacBook-Pro-Alexander.local,mylabel=boom load15=2.00341796875,n_cpus=11i,n_users=6i,load1=3.15966796875,load5=2.3837890625 1616403090000000000
+system,host=MacBook-Pro-Alexander.local,mylabel=boom load15=2.00341796876,n_cpus=13i,n_users=7i,load1=3.15966796876,load5=2.3837890626 1616403090000000000
+system,host=MacBook-Pro-Alexander.local,mylabel=boom load15=2.00341796877,n_cpus=14i,n_users=8i,load1=3.15966796877,load5=2.3837890627 1616403091000000000


### PR DESCRIPTION
Resolves a case when input contains same metrics with different time - previously those were converted into different data frames, now we put them into one. I.e. addresses [this TODO](https://github.com/grafana/grafana/blob/54ad791c7e7ff9671e3d83bae4a4b9f8754bbd5d/pkg/services/live/push/push.go#L94)